### PR TITLE
Create manual on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: bash
+script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ addons:
       - fop
       - xsltproc
 script:
-  - make pdf
+  - make html pdf

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ addons:
   apt:
     packages:
       - docbook-xsl
+      - xsltproc
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
-language: bash
+addons:
+  apt:
+    packages:
+      - docbook-xsl
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ addons:
     packages:
       - docbook-xsl
       - xsltproc
-script: make
+script:
+  - make pdf

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ addons:
   apt:
     packages:
       - docbook-xsl
+      - fop
       - xsltproc
 script:
   - make pdf

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # About the Manual 
 
+[![Build status](https://travis-ci.org/csound/manual.svg?branch=master)](https://travis-ci.org/csound/manual)
+
 The Csound Reference Manual is written in Docbook-XML. More information about
 Docbook-XML can be found at the following links:
 


### PR DESCRIPTION
This pull request builds the HTML files and PDF file of the manual on Travis CI on each commit to the master branch. It also adds a status image to README.md so people can see whether the manual can be built. (The status image currently says “build unknown” because it’s referring to csound/manual, not my fork. The build is [passing](https://travis-ci.org/nwhetsell/manual).) I’m pretty sure that all that has to happen now is someone with admin access to this repository needs to enable it in Travis CI (which is documented [here](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A)). I think the admins are @kunstmusik, @tjingboem, and @vlazzarini.