### PR TITLE
Makefile: use a stamp file when generating examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -683,7 +683,7 @@ OTHER =         STKopcodes/top.xml \
         manual.xml
         
 SRCS =  $(COMMAND) $(CONTROL) $(XMLS) $(MIDI) $(OPCODES) $(ORCH) $(SCORE) \
-	$(SIGS) $(UTILS) $(MISC) $(OTHER) examples-xml
+	$(SIGS) $(UTILS) $(MISC) $(OTHER) examples-xml/stamp
  
 # Build rules.
 all: html
@@ -694,9 +694,10 @@ $(XSL_HTML) $(XSL_HTMLHELP) $(XSL_PRINT) $(XSL_HTML_ONECHUNK): %: %.in
 	 false )
 	sed -e 's|@xsl_base_path@|$(XSL_BASE_PATH)|' $@.in > $@
 
-examples-xml: examples $(wildcard examples/*)
+examples-xml/stamp: examples $(wildcard examples/*)
 	mkdir -p examples-xml
 	python csd2docbook.py
+	touch examples-xml/stamp
 
 html: $(XSL_HTML) manual.xml $(SRCS) Makefile
 	rm -rf html


### PR DESCRIPTION
Otherwise sometimes make can get confused because the examples-xml directory exists, but there are no xml files in it. This happens if csd2docbook.py failed, or if there is a stale examples-xml dir.