### PR TITLE
Array doc caveat

### DIFF
--- a/math/array.xml
+++ b/math/array.xml
@@ -322,6 +322,14 @@ kArr[] <emphasis role="opc">xin</emphasis>
       </example>
     </para>
   </refsect1>
+
+  <refsect1>
+  <para>
+    Note that if an opcode (for example inrg), alters arguments on its right
+    hand argument list, an array index should not be used there. Unlike a
+    normal variable, the array won't changed by the opcode.
+  </para>
+  </refsect1>
   
   <refsect1>
     <title>Credits</title>


### PR DESCRIPTION
re: this discussion on the mailing list, I thought it would be helpful if the manual mentioned that array lookups don't work as "output args" on the right hand side of an opcode

https://listserv.heanet.ie/cgi-bin/wa?A2=CSOUND-DEV;7ea72327.1704

I think the wording could be improved, I'm not a good technical writer, feel free to ask any questions here if the intent is unclear.