### PR TITLE
Add appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+# https://www.appveyor.com/docs/appveyor-yml
+
+install:
+  # Install DocBook XSL.
+  - ps: Start-FileDownload 'https://github.com/docbook/xslt10-stylesheets/releases/download/release%2F1.79.2/docbook-xsl-nons-1.79.2.zip'
+  - 7z x docbook-xsl-nons-1.79.2.zip -oC:\
+  # Install Pygments.
+  - pip install pygments
+  # Install xsltproc.
+  - mkdir C:\xsltproc
+  - cd C:\xsltproc
+  - ps: Invoke-WebRequest ftp://ftp.zlatkovic.com/libxml/iconv-1.9.2.win32.zip -OutFile iconv.zip
+  - 7z e iconv.zip iconv.dll -r
+  - ps: Invoke-WebRequest ftp://ftp.zlatkovic.com/libxml/libxml2-2.7.8.win32.zip -OutFile libxml2.zip
+  - 7z e libxml2.zip libxml2.dll -r
+  - ps: Invoke-WebRequest ftp://ftp.zlatkovic.com/libxml/libxslt-1.1.26.win32.zip -OutFile libxslt.zip
+  - 7z e libxslt.zip libexslt.dll libxslt.dll xsltproc.exe -r
+  - ps: Invoke-WebRequest ftp://ftp.zlatkovic.com/libxml/zlib-1.2.5.win32.zip -OutFile zlib.zip
+  - 7z e zlib.zip zlib1.dll -r
+  - rm *.zip
+  - set PATH=%PATH%;%CD%
+  - cd %APPVEYOR_BUILD_FOLDER%
+
+build_script:
+  - set XSL_BASE_PATH=C:/docbook-xsl-nons-1.79.2
+  # Other make executables are in C:\cygwin\bin and C:\msys64\usr\bin.
+  - C:\cygwin64\bin\make html
+
+test: off


### PR DESCRIPTION
This pull request adds an appveyor.yml file that can build the HTML version of the manual on AppVeyor.

Travis CI builds a PDF file in addition to HTML files. I attempted to build the PDF file on AppVeyor, but Apache FOP tended to [run out of memory](https://xmlgraphics.apache.org/fop/2.2/running.html#memory). If anybody wants to attempt this, the simplest way to install FOP on AppVeyor is probably with [Chocolatey](https://chocolatey.org):

```bat
choco install apache-fop
```

[![Build status](https://ci.appveyor.com/api/projects/status/hfagpo3tg5g6tjd5?svg=true)](https://ci.appveyor.com/project/nwhetsell/manual)