### PR TITLE
Replace broken Soundcloud widget with a couple of working links.

### DIFF
--- a/listen.md
+++ b/listen.md
@@ -1,0 +1,9 @@
+---
+layout: sidebar_links
+title: Listen 
+---
+
+Some compositions that have been made with help of Csound can be found at these links:
+* <https://soundcloud.com/tags/csound>
+* <https://bandcamp.com/tag/csound>
+


### PR DESCRIPTION
I tried to get something embedded working here, but was unsuccessful.
I think it's better to have something not broken here, even if it's just links.