### PR TITLE
Use datadescriptor instead of qutotations for string type

### DIFF
--- a/opcodes/ftload.xml
+++ b/opcodes/ftload.xml
@@ -24,13 +24,13 @@
 
   <refsect1>
     <title>Syntax</title>
-    <synopsis><command>ftload</command> &quot;filename&quot;, iflag, ifn1 [, ifn2] [...]</synopsis>
+    <synopsis><command>ftload</command>Sfilename, iflag, ifn1 [, ifn2] [...]</synopsis>
   </refsect1>
 
   <refsect1>
     <title>Initialization</title>
     <para>
-      <emphasis>&quot;filename&quot;</emphasis> -- A quoted string containing the name of the file to load.
+      <emphasis>Sfilename</emphasis> -- A quoted string containing the name of the file to load.
     </para>
 
     <para>

--- a/opcodes/ftloadk.xml
+++ b/opcodes/ftloadk.xml
@@ -24,13 +24,13 @@
 
   <refsect1>
     <title>Syntax</title>
-    <synopsis><command>ftloadk</command> &quot;filename&quot;, ktrig, iflag, ifn1 [, ifn2] [...]</synopsis>
+    <synopsis><command>ftloadk</command> Sfilename, ktrig, iflag, ifn1 [, ifn2] [...]</synopsis>
   </refsect1>
 
   <refsect1>
     <title>Initialization</title>
     <para>
-      <emphasis>&quot;filename&quot;</emphasis> -- A quoted string containing the name of the file to load.
+      <emphasis>Sfilename</emphasis> -- A quoted string containing the name of the file to load.
     </para>
 
     <para>


### PR DESCRIPTION
I also think "quoted string" is redundant information, as string is string (aren't double curly brackets leagal too?). I hope this can increase consistency for describing types and rates in the manual :)