### PR TITLE
Csound manual improvement - links and build pre-reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ v2.1 or later; and [xsltproc](http://xmlsoft.org/XSLT/xsltproc2.html).
 
 ### On Linux
 
-To install DocBook and xsltproc, run
+To install DocBook, the required stylesheets, and xsltproc on a Debian-based system (including Ubuntu), run
 
 ```sh
-sudo apt-get install -y docbook xsltproc
+sudo apt-get install -y docbook docbook-xsl xsltproc
 ```
 
 Python is preinstalled on most Linux distributions. If you don’t have Python,

--- a/overview/building.xml
+++ b/overview/building.xml
@@ -4,7 +4,7 @@
   <para>
     Csound has become a complex project and can involve many dependencies. Unless you are a Csound developer or need to develop Csound plugins,
 you should try to use one of the precompiled distributions from <ulink
-      url="http://www.sourceforge.net/projects/csound">http://www.sourceforge.net/projects/csound</ulink>.
+      url="https://csound.com/download">https://csound.com/download</ulink>.
   </para>
   <para>
     Detailed and up to date information about building Csound from source can be found in the

--- a/overview/links.xml
+++ b/overview/links.xml
@@ -9,7 +9,7 @@
   <para>Another Csound page, maintained by Richard Boulanger, can be found at <ulink
       url="http://csounds.com">http://csounds.com</ulink>.</para>
 
-  <para>The Csound source code is maintained by John ffitch and others at <ulink url="https://github.com/csound">https://github.com/csound</ulink>. The most recent versions and precompiled packages for most platforms also can be downloaded <ulink url="http://sourceforge.net/project/showfiles.php?group_id=81968">here</ulink>.
+  <para>The Csound source code is maintained by John ffitch and others at <ulink url="https://github.com/csound">https://github.com/csound</ulink>. The most recent versions and precompiled packages for most platforms also can be downloaded <ulink url="https://csound.com/download">here</ulink>.
   </para>
 
   <para>A Csound mailing list exists to discuss Csound. It is run by

--- a/overview/links.xml
+++ b/overview/links.xml
@@ -4,11 +4,8 @@
   <title>Csound Links</title>
 
   <para>Csound's "home page" can be found at <ulink
-      url="http://csound.github.io">http://csound.github.io</ulink>.</para>
+      url="http://csound.com">http://csound.com</ulink>.</para>
       
-  <para>Another Csound page, maintained by Richard Boulanger, can be found at <ulink
-      url="http://csounds.com">http://csounds.com</ulink>.</para>
-
   <para>The Csound source code is maintained by John ffitch and others at <ulink url="https://github.com/csound">https://github.com/csound</ulink>. The most recent versions and precompiled packages for most platforms also can be downloaded <ulink url="https://csound.com/download">here</ulink>.
   </para>
 


### PR DESCRIPTION
Few minor tidyups around the links to csound.com and the prerequisites for building the manual out to HTML. Each commit is standalone and has notes in the commit message explaining the rationale.