### PR TITLE
added undocumented J input for UDOs

### DIFF
--- a/opcodes/opcode.xml
+++ b/opcodes/opcode.xml
@@ -158,6 +158,13 @@
             </row>
 
             <row>
+              <entry>J</entry>
+              <entry>optional k-rate variable, defaults to -1</entry>
+              <entry>k- and i-rate, constant</entry>
+              <entry>k-rate</entry>
+            </row>
+
+            <row>
               <entry>K</entry>
               <entry>k-rate with initialization</entry>
               <entry>k- and i-rate, constant</entry>


### PR DESCRIPTION
J defaulting to -1 has been added some time ago and works but was not in the relevant table 