### PR TITLE
ftaudio: tweak to docs and updated example

### DIFF
--- a/examples/ftaudio.csd
+++ b/examples/ftaudio.csd
@@ -19,16 +19,21 @@ giSine ftgen 0, 0, 2^10, 10, 1
 instr 1
      ktrig init    1
      asig  poscil3 .5, 880, giSine
-     kans  ftaudio ktrig, 100, "ccc.wav", 15, 1
+     kans  ftaudio ktrig, 100, "k_ftaudio.wav", 15, 1
      ktrig =       0
            outs    asig, asig
+endin
 
+instr 2
+     ians  ftaudio 100, "i_ftaudio.wav", 15, p4, p5
+           turnoff
 endin
 
 </CsInstruments>
 <CsScore>
 f100 0 0 -1 "beats.wav" 0 0 0
 i 1 0 2
+i 2 0 1 11025 33075; 0.5 seconds cut
 e
 </CsScore>
 </CsoundSynthesizer>

--- a/opcodes/ftaudio.xml
+++ b/opcodes/ftaudio.xml
@@ -114,14 +114,14 @@
     </para>
 
     <para>
-      <emphasis>ibeg</emphasis>,<emphasis>iend</emphasis>,<emphasis>kbeg</emphasis>,<emphasis>kenf</emphasis>
-      -- gives limits to start and en of section of the table to
-      write.  Defailt value of zero means from start or to end.
+      <emphasis>ibeg</emphasis>,<emphasis>iend</emphasis>,<emphasis>kbeg</emphasis>,<emphasis>kend</emphasis>
+      -- gives limits to start and end of section of the table to
+      write, in samples. Default values of zero means from start to end.
     </para>
     
     <para>
       <emphasis>ians, kans</emphasis> -- returns zero if the operation
-      fails or 1 on success.  In the asynchonous mode this is updated
+      fails or 1 on success.  In the asynchronous mode this is updated
       when the writing finishes, until when it has the value -1
     </para>
   </refsect1>


### PR DESCRIPTION
ftaudio docs: typos fix and clarification on start/end parameters.

ftaudio example: added an i_rate instrument with demonstration of start/end parameters