### PR TITLE
fix mismatch in zacl size

### DIFF
--- a/examples/zakinit.csd
+++ b/examples/zakinit.csd
@@ -17,46 +17,46 @@ nchnls = 1
 zakinit 2, 3
 
 instr 1 ;a simple waveform.
-	; Generate a simple sine waveform.
-	asin oscil 20000, 440, 1
+  ; Generate a simple sine waveform.
+  asin oscil 20000, 440, 1
 
-	; Send the sine waveform to za variable #1.
-	zaw asin, 1
+  ; Send the sine waveform to za variable #1.
+  zaw asin, 1
 endin
 
 instr 2  ;generates audio output.
-	; Read za variable #1.
-	a1 zar 1
+  ; Read za variable #1.
+  a1 zar 1
 
-	; Generate audio output.
-	out a1
+  ; Generate audio output.
+  out a1
 
-	; Clear the za variables, get them ready for 
-	; another pass.
-	zacl 0, 3
+  ; Clear the za variables, get them ready for
+  ; another pass.
+  zacl 0, 2
 endin
 
 instr 3  ;increments k-type channels
-	k0 zkr 0
-	k1 zkr 1
-	k2 zkr 2
+  k0 zkr 0
+  k1 zkr 1
+  k2 zkr 2
 
-	zkw k0+1, 0
-	zkw k1+5, 1
-	zkw k2+10, 2
+  zkw k0+1, 0
+  zkw k1+5, 1
+  zkw k2+10, 2
 endin
 
 instr 4 ;displays values from k-type channels
-	k0 zkr 0
-	k1 zkr 1
-	k2 zkr 2
+  k0 zkr 0
+  k1 zkr 1
+  k2 zkr 2
 
-; The total count for k0 is 30, since there are 10
-; control blocks per second and intruments 3 and 4
-; are on for 3 seconds.
-	printf "k0 = %i\n",k0, k0
-	printf "k1 = %i\n",k1, k1
-	printf "k2 = %i\n",k2, k2
+  ; The total count for k0 is 30, since there are 10
+  ; control blocks per second and intruments 3 and 4
+  ; are on for 3 seconds.
+  printf "k0 = %i\n",k0, k0
+  printf "k1 = %i\n",k1, k1
+  printf "k2 = %i\n",k2, k2
 endin
 
 </CsInstruments>


### PR DESCRIPTION
The current error produced by the example `zakinit.csd` is

```
PERF ERROR in instr 2 line 36: zacl first or last > isizea. Not clearing.
 from file zakinit.csd (1)
```

That's because it's initialized to 2 a-rate channels but tries to clear 3.

Also fixed the indentation.