### PR TITLE
Updating chnget/chnset manual entries with new array based opcodes..

### DIFF
--- a/opcodes/chnget.xml
+++ b/opcodes/chnget.xml
@@ -124,6 +124,7 @@
       <simplelist>
         <member>Author: &nameistvan;</member>
         <member>2005</member>
+        <member>Array based channel opcodes added to 6.14 - Rory Walsh</member>
       </simplelist>
     </para>
   </refsect1>

--- a/opcodes/chnget.xml
+++ b/opcodes/chnget.xml
@@ -29,6 +29,10 @@
     <synopsis>aval <command>chnget</command> Sname</synopsis>
     <synopsis>Sval <command>chnget</command> Sname</synopsis>
      <synopsis>Sval <command>chngetks</command> Sname</synopsis>
+    <synopsis>ival[] <command>chngeti</command> Sname[]</synopsis>
+    <synopsis>kval[] <command>chngetk</command> Sname[]</synopsis>
+    <synopsis>aval[] <command>chngets</command> Sname[]</synopsis>
+    <synopsis>Sval[] <command>chngets</command> Sname[]</synopsis>
   </refsect1>
 
   <refsect1>
@@ -38,10 +42,19 @@
       of the named software bus to read.
     </para>
     <para>
+      <emphasis>Sname[]</emphasis> -- an array of named software channels to query.
+    </para>
+    <para>
       <emphasis>ival</emphasis> -- the control value read at i-time.
     </para>
     <para>
       <emphasis>Sval</emphasis> -- the string value read at i-time.
+    </para>
+    <para>
+      <emphasis>ival[]</emphasis> -- an array of control values read at i-time.
+    </para>
+    <para>
+      <emphasis>Sval{}</emphasis> -- an array of strings read at i-time.
     </para>
   </refsect1>
 
@@ -51,7 +64,13 @@
       <emphasis>kval</emphasis> -- the control value read at performance time.
     </para>
     <para>
+      <emphasis>kval[]</emphasis> -- an array of control values read at performance time.
+    </para>
+    <para>
       <emphasis>aval</emphasis> -- the audio signal read at performance time.
+    </para>
+    <para>
+      <emphasis>aval</emphasis> -- the audio of audio vectors read at performance time.
     </para>
      <para>
       <emphasis>Sval</emphasis> -- the string value read at
@@ -61,6 +80,13 @@
     </para>
   </refsect1>
 
+  <note>
+    <para>
+      Although it is possible to loop through channel names from an array with <emphasis>chnget</emphasis> and <emphasis>chnset</emphasis>, 
+      using the array based variants is more efficient.        
+    </para> 
+  </note>
+  
   <refsect1>
     <title>Example</title>
     <para>

--- a/opcodes/chnget.xml
+++ b/opcodes/chnget.xml
@@ -31,7 +31,7 @@
      <synopsis>Sval <command>chngetks</command> Sname</synopsis>
     <synopsis>ival[] <command>chngeti</command> Sname[]</synopsis>
     <synopsis>kval[] <command>chngetk</command> Sname[]</synopsis>
-    <synopsis>aval[] <command>chngets</command> Sname[]</synopsis>
+    <synopsis>aval[] <command>chngeta</command> Sname[]</synopsis>
     <synopsis>Sval[] <command>chngets</command> Sname[]</synopsis>
   </refsect1>
 
@@ -70,7 +70,7 @@
       <emphasis>aval</emphasis> -- the audio signal read at performance time.
     </para>
     <para>
-      <emphasis>aval</emphasis> -- the audio of audio vectors read at performance time.
+      <emphasis>aval[]</emphasis> -- the audio of audio vectors read at performance time.
     </para>
      <para>
       <emphasis>Sval</emphasis> -- the string value read at

--- a/opcodes/chnget.xml
+++ b/opcodes/chnget.xml
@@ -124,7 +124,7 @@
       <simplelist>
         <member>Author: &nameistvan;</member>
         <member>2005</member>
-        <member>Array based channel opcodes added to 6.14 - Rory Walsh</member>
+        <member>Array based channel opcodes added in version 6.14 - Rory Walsh</member>
       </simplelist>
     </para>
   </refsect1>

--- a/opcodes/chnset.xml
+++ b/opcodes/chnset.xml
@@ -29,6 +29,10 @@
     <synopsis><command>chnset</command> aval, Sname</synopsis>
     <synopsis><command>chnset</command> Sval, Sname</synopsis>
     <synopsis><command>chnsetks</command> Sval, Sname</synopsis>
+    <synopsis><command>chnseti</command> ival[], []Sname</synopsis>
+    <synopsis><command>chnsetk</command> kval[], []Sname</synopsis>
+    <synopsis><command>chnseta</command> aval[], []Sname</synopsis>
+    <synopsis><command>chnsets</command> Sval[], []Sname</synopsis>
   </refsect1>
 
   <refsect1>
@@ -38,11 +42,21 @@
       named channel of the software bus to write.
     </para>
     <para>
+      <emphasis>Sname[]</emphasis> -- an array of string that indicates which
+      named channels of the software bus to write to.
+    </para>
+    <para>
       <emphasis>ival</emphasis> -- the control value to write at i-time.
+    </para>
+    <para>
+      <emphasis>ival[]</emphasis> -- an array of control values to write at i-time.
     </para>
     <para>
       <emphasis>Sval</emphasis> -- the string value to write at i-time.
     </para>
+    <para>
+      <emphasis>Sval[]</emphasis> -- an array of string values to write at i-time.
+    </para>    
   </refsect1>
 
   <refsect1>
@@ -61,9 +75,27 @@
       perf-time, whereas chnsetks works only a perf-time. Channel
       contents are only updated if the string variable is modified.
     </para>
-
+    <para>
+      <emphasis>kval[]</emphasis> -- an array of control value to write at performance
+      time.
+    </para>
+    <para>
+      <emphasis>aval[]</emphasis> -- an array of audio vectors to write at performance
+      time.
+    </para>
+    <para>
+      <emphasis>Sval[]</emphasis> -- an array of string values to write at
+      perf-time. 
+    </para>
   </refsect1>
 
+  <note>
+    <para>
+      Although it is possible to loop through channel names from an array with <emphasis>chnget</emphasis> and <emphasis>chnset</emphasis>, 
+      using the array based variants is more efficient.        
+    </para> 
+  </note>
+  
   <refsect1>
     <title>Example</title>
     <para>

--- a/opcodes/chnset.xml
+++ b/opcodes/chnset.xml
@@ -76,16 +76,12 @@
       contents are only updated if the string variable is modified.
     </para>
     <para>
-      <emphasis>kval[]</emphasis> -- an array of control value to write at performance
+      <emphasis>kval[]</emphasis> -- an array of control values to write at performance
       time.
     </para>
     <para>
       <emphasis>aval[]</emphasis> -- an array of audio vectors to write at performance
       time.
-    </para>
-    <para>
-      <emphasis>Sval[]</emphasis> -- an array of string values to write at
-      perf-time. 
     </para>
   </refsect1>
 
@@ -131,6 +127,7 @@
       <simplelist>
         <member>Author: &nameistvan;</member>
         <member>2005</member>
+        <member>Array based channel opcodes added in version 6.14 - Rory Walsh</member>
       </simplelist>
     </para>
   </refsect1>

--- a/opcodes/chnset.xml
+++ b/opcodes/chnset.xml
@@ -92,7 +92,7 @@
   <note>
     <para>
       Although it is possible to loop through channel names from an array with <emphasis>chnget</emphasis> and <emphasis>chnset</emphasis>, 
-      using the array based variants is more efficient.        
+      using the array based channel opcodes is more efficient.        
     </para> 
   </note>
   


### PR DESCRIPTION
I can put these into their own manual page, but felt they would be more visible to users if placed within the current `chnget`/`chnset` page. 