### PR TITLE
Corrections to midi-interop and envlpx.. opcode descriptions

### DIFF
--- a/opcodes/envlpx.xml
+++ b/opcodes/envlpx.xml
@@ -59,26 +59,27 @@
     </para>
 
     <para>
-      <emphasis>iatss</emphasis> -- attenuation factor, by which the
-      last value of the <emphasis>envlpx</emphasis> rise is modified
-      during the note's pseudo steady state. A factor greater than 1
-      causes an exponential growth and a factor less than 1 creates an
-      exponential decay. A factor of 1 will maintain a true steady
-      state at the last rise value. Note that this attenuation is not
-      by fixed rate (as in a piano), but is sensitive to a note's
-      duration. However, if <emphasis>iatss</emphasis> is negative (or
+      <emphasis>iatss</emphasis> -- the ratio of the final value
+      of the pseudo-steady-state period to the value at its beginning
+      (i.e the attenuation from the end of the rise segment
+      to the start of the decay).
+      A ratio greater than 1 causes an exponential growth and 
+      a ratio less than 1 creates an exponential decay. A ratio of 1
+      will maintain a true steady state at the last rise value.
+      Note that this attenuation is not at a fixed rate (as in a piano),
+      but is sensitive to a note's duration. 
+      However, if <emphasis>iatss</emphasis> is negative (or
       if steady state &lt; 4 k-periods) a fixed attenuation rate of
       <emphasis>abs</emphasis>(<emphasis>iatss</emphasis>) per second
       will be used. 0 is illegal. 
     </para>
 
     <para>
-      <emphasis>iatdec</emphasis> -- attenuation factor by which the
-      closing steady state value is reduced exponentially over the
-      decay period. This value must be positive and is normally of the
-      order of .01. A large or excessively small value is apt to
-      produce a cutoff which is audible. A zero or negative value is
-      illegal.
+      <emphasis>iatdec</emphasis> --  the ratio of the value
+      at the end of the decay period to the value at its beginning (the end
+      of the steady-state segment) . It must be positive and is normally of the
+      order of .01. A large or excessively small value is apt to produce a cutoff
+      which is audible. A zero or negative value is illegal.
     </para>
 
     <para>

--- a/opcodes/envlpxr.xml
+++ b/opcodes/envlpxr.xml
@@ -42,11 +42,22 @@
     </para>
 
     <para>
-      <emphasis>iatss</emphasis> -- attenuation factor, by which the last value of the <emphasis>envlpxr</emphasis> rise is modified during the note's pseudo steady state. A factor greater than 1 causes an exponential growth and a factor less than 1 creates an exponential decay. A factor of 1 will maintain a true steady state at the last rise value.  Note that this attenuation is not by fixed rate (as in a piano), but is sensitive to a note's duration. However, if <emphasis>iatss</emphasis> is negative (or if steady state &lt; 4 k-periods) a fixed attenuation rate of <emphasis>abs</emphasis>(<emphasis>iatss</emphasis>) per second will be used. 0 is illegal.
+      <emphasis>iatss</emphasis> --  attenuation factor determining the
+      exponential change in value over time during the pseudo steady state
+      period between the end of the rise and the beginning of the decay
+      (at the note's release).  A factor greater than 1 causes an exponential
+      growth and a factor less than 1 creates an exponential decay. A factor
+      of 1 will maintain a true steady state at the last rise value; 0 is illegal.
+      The value will change by
+      <emphasis>abs</emphasis>(<emphasis>iatss</emphasis>) per second.
     </para>
 
     <para>
-      <emphasis>iatdec</emphasis> -- attenuation factor by which the closing steady state value is reduced exponentially over the decay period. This value must be positive and is normally of the order of .01. A large or excessively small value is apt to produce a cutoff which is audible. A zero or negative value is illegal.
+      <emphasis>iatdec</emphasis> --  the ratio of the value
+      at the end of the decay period to the value at its beginning (when
+      the note is released). It must be positive and is normally of the
+      order of .01. A large or excessively small value is apt to produce
+      a cutoff which is audible. A zero or negative value is illegal.
     </para>
 
     <para>
@@ -70,10 +81,6 @@
 
     <para>
       You can use other pre-made envelopes which start a release segment upon receiving a note off message, like <link linkend="linsegr"><citetitle>linsegr</citetitle></link> and <link linkend="expsegr"><citetitle>expsegr</citetitle></link>, or you can construct more complex envelopes using <link linkend="xtratim"><citetitle>xtratim</citetitle></link> and <link linkend="release"><citetitle>release</citetitle></link>. Note that you don't need to use <link linkend="xtratim"><citetitle>xtratim</citetitle></link> if you are using <emphasis>envlpxr</emphasis>, since the time is extended automatically.
-    </para>
-
-    <para>
-      These <quote>r</quote> units can also be modified by MIDI noteoff velocities (see veloffs). If the <emphasis>irind</emphasis> flag is on (non-zero), the overall performance time is unaffected by note-off and veloff data.
     </para>
 
     <formalpara>

--- a/opcodes/midicontrolchange.xml
+++ b/opcodes/midicontrolchange.xml
@@ -50,7 +50,7 @@ and MIDI, including both MIDI files and real-time MIDI input, without using any 
   <refsect1>
     <title>Performance</title>
     <para>
-      <emphasis>xcontroller</emphasis> -- specifies a MIDI controller number (0-127).
+      <emphasis>xcontroller</emphasis> -- specifies the MIDI controller number (0-127) to read from.
     </para>
 
     <para>
@@ -58,7 +58,7 @@ and MIDI, including both MIDI files and real-time MIDI input, without using any 
     </para>
 
     <para>
-      If the instrument was activated by MIDI input, the opcode overwrites the values of the <emphasis>xcontroller</emphasis> and <emphasis>xcontrollervalue</emphasis> with the corresponding values from MIDI input. If the instrument was <emphasis>NOT</emphasis> activated by MIDI input, the values of <emphasis>xcontroller</emphasis> and <emphasis>xcontrollervalue</emphasis> remain unchanged.
+      If the instrument was activated by MIDI input, the opcode overwrites the value of  <emphasis>xcontrollervalue</emphasis> with the corresponding value from the MIDI data of the specified <emphasis>xcontroller</emphasis>. If the instrument was <emphasis>NOT</emphasis> activated by MIDI input, the value remains unchanged.
     </para>
 
     <para>

--- a/opcodes/midinoteoff.xml
+++ b/opcodes/midinoteoff.xml
@@ -18,6 +18,10 @@
   <refsect1>
     <title>Description</title>
     <para>
+    This opcode is incorrect. It is <emphasis>identical</emphasis> to <emphasis>midinoteonkey</emphasis>. It does not respond
+to Note-Off events, but is activated by Note-On. It does not do what you would expect from its name.
+    </para>
+    <para>
       <emphasis>midinoteoff</emphasis> is designed to simplify writing instruments that can be used interchangeably for either score or MIDI input, and to make it easier to adapt instruments originally written for score input to work with MIDI input.
     </para>
 

--- a/opcodes/midinoteoff.xml
+++ b/opcodes/midinoteoff.xml
@@ -18,8 +18,9 @@
   <refsect1>
     <title>Description</title>
     <para>
-    This opcode is incorrect. It is <emphasis>identical</emphasis> to <emphasis>midinoteonkey</emphasis>. It does not respond
-to Note-Off events, but is activated by Note-On. It does not do what you would expect from its name.
+   This opcode is incorrect. It is <emphasis>identical</emphasis> to <emphasis>midinoteonkey</emphasis>.
+   It does not do what you would expect from its name, as it does not respond to Note-Off events, but is activated by Note-On.
+   The <emphasis>midiin</emphasis> opcode can be used to receive noteoff events and their velocities.
     </para>
     <para>
       <emphasis>midinoteoff</emphasis> is designed to simplify writing instruments that can be used interchangeably for either score or MIDI input, and to make it easier to adapt instruments originally written for score input to work with MIDI input.

--- a/opcodes/midipolyaftertouch.xml
+++ b/opcodes/midipolyaftertouch.xml
@@ -33,7 +33,7 @@ and MIDI, including both MIDI files and real-time MIDI input, without using any 
 
   <refsect1>
     <title>Syntax</title>
-    <synopsis><command>midipolyaftertouch</command> xpolyaftertouch, xcontrollervalue [, ilow] [, ihigh]</synopsis>
+    <synopsis><command>midipolyaftertouch</command> xpolyaftertouch, xkey [, ilow] [, ihigh]</synopsis>
   </refsect1>
 
   <refsect1>
@@ -50,17 +50,16 @@ and MIDI, including both MIDI files and real-time MIDI input, without using any 
   <refsect1>
     <title>Performance</title>
     <para>
-      <emphasis>xpolyaftertouch</emphasis> -- returns MIDI polyphonic aftertouch during MIDI activation, remains unchanged otherwise.
+      <emphasis>xpolyaftertouch</emphasis> -- returns MIDI polyphonic aftertouch of the selected note during MIDI activation, remains unchanged otherwise.
     </para>
 
     <para>
-      <emphasis>xcontrollervalue</emphasis> -- returns the value of the MIDI controller during MIDI activation, remains unchanged otherwise.
+      <emphasis>xkey</emphasis> -- specifies the MIDI key to read from.  It normally should be set to the note number that the instrument instance is playing.
     </para>
 
     <para>
-      If the instrument was activated by MIDI input, the opcode overwrites the values of <emphasis>xpolyaftertouch</emphasis> and <emphasis>xcontrollervalue</emphasis> with the corresponding values from MIDI input. If the instrument was <emphasis>NOT</emphasis> activated by MIDI input, the values of <emphasis>xpolyaftertouch</emphasis> and <emphasis>xcontrollervalue</emphasis> remain unchanged.
+      If the instrument was activated by MIDI input, the opcode overwrites the value of <emphasis>xpolyaftertouch</emphasis>  with the corresponding value from MIDI input. If the instrument was <emphasis>NOT</emphasis> activated by MIDI input, the value remains unchanged.
     </para>
-
     <para>
       This enables score p-fields to receive MIDI input data during MIDI activation, and score values otherwise.
     </para>


### PR DESCRIPTION
Descriptions of 3 of the opcodes were incorrect:

midicontrolchange was shown as having two output arguments. Actually one is input.

midipolyaftertouch had similarly miscategorized arguments, and one name was inappropriate.

midinoteoff does not actually handle note-offs!  A note was added to that effect.
