### PR TITLE
More cleanups for Orch Macros

### DIFF
--- a/opcodes/define.xml
+++ b/opcodes/define.xml
@@ -181,6 +181,9 @@ Macro definition for OSCMACRO</screen>
     <title>See Also</title>
     <para>
       <link linkend="dollar"><citetitle>&dollar;NAME</citetitle></link>,
+      <link linkend="ifdef"><citetitle>&num;ifdef</citetitle></link>,
+      <link linkend="ifndef"><citetitle>&num;ifndef</citetitle></link>,
+      <link linkend="include"><citetitle>&num;include</citetitle></link>,
       <link linkend="undef"><citetitle>&num;undef</citetitle></link>
     </para>
   </refsect1>

--- a/opcodes/define.xml
+++ b/opcodes/define.xml
@@ -18,7 +18,7 @@
   <refsect1>
     <title>Description</title>
     <para>
-      Macros are textual replacements which are made in the orchestra as it is being read.  The macro system in Csound is a very simple one, and uses the characters &num; and &dollar; to define and call macros. This can save typing, and can lead to a coherent structure and consistent style.  This is similar to, but independent of, the <link linkend="ScoreMacros"><citetitle>macro system in the score language</citetitle></link>.
+      Macros are textual replacements which are made in the orchestra as it is being read.  The <link linkend="OrchMacros"><citetitle>orchestra macro system</citetitle></link> in Csound is a very simple one, and uses the characters &num; and &dollar; to define and call macros. This can save typing, and can lead to a coherent structure and consistent style.  This is similar to, but independent of, the <link linkend="ScoreMacros"><citetitle>macro system in the score language</citetitle></link>.
     </para>
 
     <para>

--- a/opcodes/dollar.xml
+++ b/opcodes/dollar.xml
@@ -97,6 +97,9 @@ Macro definition for OSCMACRO</screen>
     <title>See Also</title>
     <para>
       <link linkend="define"><citetitle>&num;define</citetitle></link>,
+      <link linkend="ifdef"><citetitle>&num;ifdef</citetitle></link>,
+      <link linkend="ifndef"><citetitle>&num;ifndef</citetitle></link>,
+      <link linkend="include"><citetitle>&num;include</citetitle></link>,
       <link linkend="undef"><citetitle>&num;undef</citetitle></link>
     </para>
   </refsect1>

--- a/opcodes/dollar.xml
+++ b/opcodes/dollar.xml
@@ -23,7 +23,7 @@
   <refsect1>
     <title>Description</title>
     <para>
-      Macros are textual replacements which are made in the orchestra as it is being read.  The macro system in Csound is a very simple one, and uses the characters &num; and &dollar; to define and call macros. This can save typing, and can lead to a coherent structure and consistent style.  This is similar to, but independent of, the <link linkend="ScoreMacros"><citetitle>macro system in the score language</citetitle></link>.
+      Macros are textual replacements which are made in the orchestra as it is being read.  The <link linkend="OrchMacros"><citetitle>orchestra macro system</citetitle></link> in Csound is a very simple one, and uses the characters &num; and &dollar; to define and call macros. This can save typing, and can lead to a coherent structure and consistent style.  This is similar to, but independent of, the <link linkend="ScoreMacros"><citetitle>macro system in the score language</citetitle></link>.
     </para>
 
     <para>

--- a/opcodes/ifdef.xml
+++ b/opcodes/ifdef.xml
@@ -21,12 +21,13 @@
   <refsect1>
     <title>Description</title>
     <para>
+      Macros are textual replacements which are made in the orchestra as it is being read.  The <link linkend="OrchMacros"><citetitle>orchestra macro system</citetitle></link> in Csound is a very simple one, and uses the characters &num; and &dollar; to define and call macros. This can save typing, and can lead to a coherent structure and consistent style.  This is similar to, but independent of, the <link linkend="ScoreMacros"><citetitle>macro system in the score language</citetitle></link>.
+    </para>
+
+    <para>
       If a macro is defined then <emphasis>&num;ifdef</emphasis> can
     incorporate text into an orchestra upto the next
     <emphasis>&num;end</emphasis>.  
-    This is similar to, but independent of, the <link
-    linkend="ScoreMacros"><citetitle>macro system in the score
-    language</citetitle></link>.  
     </para>
 
   </refsect1>

--- a/opcodes/ifdef.xml
+++ b/opcodes/ifdef.xml
@@ -85,9 +85,11 @@
   <refsect1>
     <title>See Also</title>
     <para>
-      <link linkend="dollar"><citetitle>&dollar;NAME</citetitle></link>, 
-      <link linkend="define"><citetitle>&num;define</citetitle></link>, 
-      <link linkend="ifndef"><citetitle>&num;ifndef</citetitle></link>.
+      <link linkend="define"><citetitle>&num;define</citetitle></link>,
+      <link linkend="dollar"><citetitle>&dollar;NAME</citetitle></link>,
+      <link linkend="ifndef"><citetitle>&num;ifndef</citetitle></link>,
+      <link linkend="include"><citetitle>&num;include</citetitle></link>,
+      <link linkend="undef"><citetitle>&num;undef</citetitle></link>
     </para>
   </refsect1>
  

--- a/opcodes/ifndef.xml
+++ b/opcodes/ifndef.xml
@@ -21,12 +21,13 @@
   <refsect1>
     <title>Description</title>
     <para>
+      Macros are textual replacements which are made in the orchestra as it is being read.  The <link linkend="OrchMacros"><citetitle>orchestra macro system</citetitle></link> in Csound is a very simple one, and uses the characters &num; and &dollar; to define and call macros. This can save typing, and can lead to a coherent structure and consistent style.  This is similar to, but independent of, the <link linkend="ScoreMacros"><citetitle>macro system in the score language</citetitle></link>.
+    </para>
+  
+    <para>
       If the specified macro is not defined then <emphasis>&num;ifndef</emphasis> can
     incorporate text into an orchestra upto the next
     <emphasis>&num;end</emphasis>.  
-    This is similar to, but independent of, the <link
-    linkend="ScoreMacros"><citetitle>macro system in the score
-    language</citetitle></link>.
     </para>
 
   </refsect1>

--- a/opcodes/ifndef.xml
+++ b/opcodes/ifndef.xml
@@ -73,9 +73,11 @@
   <refsect1>
     <title>See Also</title>
     <para>
-      <link linkend="dollar"><citetitle>&dollar;NAME</citetitle></link>, 
       <link linkend="define"><citetitle>&num;define</citetitle></link>,
-      <link linkend="ifdef"><citetitle>&num;ifdef</citetitle></link>.
+      <link linkend="dollar"><citetitle>&dollar;NAME</citetitle></link>,
+      <link linkend="ifdef"><citetitle>&num;ifdef</citetitle></link>,
+      <link linkend="include"><citetitle>&num;include</citetitle></link>,
+      <link linkend="undef"><citetitle>&num;undef</citetitle></link>
     </para>
   </refsect1>
  

--- a/opcodes/include.xml
+++ b/opcodes/include.xml
@@ -21,6 +21,10 @@
   <refsect1>
     <title>Description</title>
     <para>
+      Macros are textual replacements which are made in the orchestra as it is being read.  The <link linkend="OrchMacros"><citetitle>orchestra macro system</citetitle></link> in Csound is a very simple one, and uses the characters &num; and &dollar; to define and call macros. This can save typing, and can lead to a coherent structure and consistent style.  This is similar to, but independent of, the <link linkend="ScoreMacros"><citetitle>macro system in the score language</citetitle></link>.
+    </para>
+    
+    <para>
       Includes an external file for processing.
     </para>
   </refsect1>

--- a/opcodes/include.xml
+++ b/opcodes/include.xml
@@ -106,6 +106,17 @@ $BASSOON(3)</programlisting>
   </refsect1>
 
   <refsect1>
+    <title>See Also</title>
+    <para>
+      <link linkend="define"><citetitle>&num;define</citetitle></link>,
+      <link linkend="dollar"><citetitle>&dollar;NAME</citetitle></link>,
+      <link linkend="ifdef"><citetitle>&num;ifdef</citetitle></link>,
+      <link linkend="ifndef"><citetitle>&num;ifndef</citetitle></link>,
+      <link linkend="undef"><citetitle>&num;undef</citetitle></link>
+    </para>
+  </refsect1>
+
+  <refsect1>
     <title>Credits</title>
     <para>
       <simplelist>

--- a/opcodes/undef.xml
+++ b/opcodes/undef.xml
@@ -23,7 +23,7 @@
   <refsect1>
     <title>Description</title>
     <para>
-      Macros are textual replacements which are made in the orchestra as it is being read.  The macro system in Csound is a very simple one, and uses the characters &num; and &dollar; to define and call macros. This can save typing, and can lead to a coherent structure and consistent style.  This is similar to, but independent of, the <link linkend="ScoreMacros"><citetitle>macro system in the score language</citetitle></link>.
+      Macros are textual replacements which are made in the orchestra as it is being read.  The <link linkend="OrchMacros"><citetitle>orchestra macro system</citetitle></link> in Csound is a very simple one, and uses the characters &num; and &dollar; to define and call macros. This can save typing, and can lead to a coherent structure and consistent style.  This is similar to, but independent of, the <link linkend="ScoreMacros"><citetitle>macro system in the score language</citetitle></link>.
     </para>
 
     <para>

--- a/opcodes/undef.xml
+++ b/opcodes/undef.xml
@@ -47,7 +47,10 @@
     <title>See Also</title>
     <para>
       <link linkend="define"><citetitle>&num;define</citetitle></link>,
-      <link linkend="dollar"><citetitle>&dollar;NAME</citetitle></link>
+      <link linkend="dollar"><citetitle>&dollar;NAME</citetitle></link>,
+      <link linkend="ifdef"><citetitle>&num;ifdef</citetitle></link>,
+      <link linkend="ifndef"><citetitle>&num;ifndef</citetitle></link>,
+      <link linkend="include"><citetitle>&num;include</citetitle></link>
     </para>
   </refsect1>
  

--- a/orch/macros.xml
+++ b/orch/macros.xml
@@ -1,6 +1,6 @@
 
 <section id="OrchMacros">
-  <title>Macros</title>
+  <title>Orchestra Macros</title>
 
   <para>
     Orchestra macros work like C preprocessor macros, and replace the content of the macro in the orchestra before it is compiled. The opcodes one can use to create, call, or undefine orchestra macros are:

--- a/orch/macros.xml
+++ b/orch/macros.xml
@@ -26,7 +26,7 @@
     These opcodes refer to orchestra macros; for score macros, refer to <link linkend="ScoreMacros"><citetitle>Score Macros</citetitle></link>. 
   </para>
 
-  <refsect1 id="opcodesDefineMathConstMacros">
+  <refsect1 id="opcodesOrchMathConstMacros">
     <title>Predefined Math Constant Macros</title>
     <para>New in Csound 5.04 are predefined Math Constant Macros.  The values
     defined are those found in the C header math.h, and are automatically

--- a/orch/macros.xml
+++ b/orch/macros.xml
@@ -26,4 +26,96 @@
     These opcodes refer to orchestra macros; for score macros, refer to <link linkend="ScoreMacros"><citetitle>Score Macros</citetitle></link>. 
   </para>
 
+  <refsect1 id="opcodesDefineMathConstMacros">
+    <title>Predefined Math Constant Macros</title>
+    <para>New in Csound 5.04 are predefined Math Constant Macros.  The values
+    defined are those found in the C header math.h, and are automatically
+    defined when Csound starts and available for use in orchestras.</para>
+
+    <informaltable frame="all">
+        <tgroup cols="3" colsep="1" rowsep="1">
+          <thead>
+            <row>
+              <entry>Macro</entry>
+              <entry>Value</entry>
+              <entry>Equivalent to</entry>
+            </row>
+          </thead>
+
+          <tbody>
+
+            <row>
+              <entry>$M_E</entry>
+              <entry>2.7182818284590452354</entry>
+              <entry>e</entry>
+            </row>
+            <row>
+              <entry>$M_LOG2E</entry>
+              <entry>1.4426950408889634074</entry>
+              <entry>log_2(e)</entry>
+            </row>
+            <row>
+              <entry>$M_LOG10E</entry>
+              <entry>0.43429448190325182765</entry>
+              <entry>log_10(e)</entry>
+            </row>
+            <row>
+              <entry>$M_LN2</entry>
+              <entry>0.69314718055994530942</entry>
+              <entry>log_e(2)</entry>
+            </row>
+            <row>
+              <entry>$M_LN10</entry>
+              <entry>2.30258509299404568402</entry>
+              <entry>log_e(10)</entry>
+            </row>
+            <row>
+              <entry>$M_PI</entry>
+              <entry>3.14159265358979323846</entry>
+              <entry>pi</entry>
+            </row>
+            <row>
+              <entry>$M_PI_2</entry>
+              <entry>1.57079632679489661923</entry>
+              <entry>pi/2</entry>
+            </row>
+            <row>
+              <entry>$M_PI_4</entry>
+              <entry>0.78539816339744830962</entry>
+              <entry>pi/4</entry>
+            </row>
+            <row>
+              <entry>$M_1_PI</entry>
+              <entry>0.31830988618379067154</entry>
+              <entry>1/pi</entry>
+            </row>
+            <row>
+              <entry>$M_2_PI</entry>
+              <entry>0.63661977236758134308</entry>
+              <entry>2/pi</entry>
+            </row>
+            <row>
+              <entry>$M_2_SQRTPI</entry>
+              <entry>1.12837916709551257390</entry>
+              <entry>2/sqrt(pi)</entry>
+            </row>
+            <row>
+              <entry>$M_SQRT2</entry>
+              <entry>1.41421356237309504880</entry>
+              <entry>sqrt(2)</entry>
+            </row>
+            <row>
+              <entry>$M_SQRT1_2</entry>
+              <entry>0.70710678118654752440</entry>
+              <entry>1/sqrt(2)</entry>
+            </row>
+
+          </tbody>
+        </tgroup>
+      </informaltable>
+
+
+  </refsect1>
+
+
 </section>


### PR DESCRIPTION
Attempts to standardize cross reference links between macro manual pages

Add math macros to main page

Added link back to OrchMacros.html from all macro pages for better visibility.

Standardized message about Orch and Score macros on all orch macro manual pages.

Update OrchMacro title to match ScoreMacro: now "Orchestra Macros" instead of "Macros"