### PR TITLE
src_conv as replacement to srconv

### DIFF
--- a/utility/convert.xml
+++ b/utility/convert.xml
@@ -1,6 +1,6 @@
 
 <section id="UtilityConversion">
-  <title>File Conversion (<!--DNOISE, -->HET_IMPORT, HET_EXPORT, PVLOOK, PV_EXPORT, PV_IMPORT, SDIF2AD, SRCONV)</title>
+  <title>File Conversion (<!--DNOISE, -->HET_IMPORT, HET_EXPORT, PVLOOK, PV_EXPORT, PV_IMPORT, SDIF2AD, SRC_CONV)</title>
   <para>The following utilities exist for file conversion:
     <itemizedlist>
 <!--      <listitem>
@@ -40,11 +40,6 @@
       </listitem>
       <listitem>
         <para>
-          <link linkend="srconv"><citetitle>SRCONV</citetitle></link>: Converts the sample rate of an audio file.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
           <link linkend="src_conv"><citetitle>SRC_CONV</citetitle></link>: Converts the sample rate of an audio file.
         </para>
       </listitem>
@@ -58,6 +53,5 @@
   &utilitypv_export;
   &utilitypv_import;
   &utilitysdif2ad;
-  &utilitysrconv;
   &utilitysrc_conv;
 </section>

--- a/utility/convertXO.xml
+++ b/utility/convertXO.xml
@@ -1,6 +1,6 @@
 
 <section id="UtilityConversion">
-  <title>File Conversion (DNOISE, HET_IMPORT, HET_EXPORT, PVLOOK, PV_EXPORT, PV_IMPORT, SDIF2AD, SRCONV)</title>
+  <title>File Conversion (DNOISE, HET_IMPORT, HET_EXPORT, PVLOOK, PV_EXPORT, PV_IMPORT, SDIF2AD, SRC_CONV)</title>
   <para>The following utilities exist for file conversion:
     <itemizedlist>
       <listitem>
@@ -40,7 +40,7 @@
       </listitem>
       <listitem>
         <para>
-          <link linkend="srconv"><citetitle>SRCONV</citetitle></link>: Converts the sample rate of an audio file.
+          <link linkend="src_conv"><citetitle>SRC_CONV</citetitle></link>: Converts the sample rate of an audio file.
         </para>
       </listitem>
     </itemizedlist>
@@ -53,5 +53,5 @@
   &utilitypv_export;
   &utilitypv_import;
   &utilitysdif2ad;
-  &utilitysrconv;
+  &utilitysrc_conv;
 </section>

--- a/utility/src_conv.xml
+++ b/utility/src_conv.xml
@@ -50,7 +50,7 @@
         <listitem><para>-<emphasis>J</emphasis> = create an IRCAM
     format output soundfile</para></listitem> 
         <listitem><para>-<emphasis>W</emphasis> = create a WAV format
-    output soundfile</para></listitem> 
+    output soundfile (default after Csound version 6.14)</para></listitem> 
         <listitem><para>-<emphasis>h</emphasis> = no header on output
     soundfile</para></listitem> 
         <listitem><para>-<emphasis>c</emphasis> = 8-bit signed_char
@@ -108,12 +108,6 @@
     </para>
   </refsect1>
  
-  <refsect1>
-    <title>See Also</title>
-    <para>
-      <link linkend="srconv"><citetitle>srconv</citetitle></link>
-    </para>
-  </refsect1>
 
 <refsect1>
     <title>Credits</title>

--- a/utility/srconv.xml
+++ b/utility/srconv.xml
@@ -8,119 +8,14 @@
   <refnamediv>
     <refname>srconv</refname>
     <refpurpose>
-      Converts the sample rate of an audio file.
-      <indexterm id="IndexSrconv"><primary>srconv</primary></indexterm>
+      Deprecated.
     </refpurpose>
   </refnamediv>
  
   <refsect1>
     <title>Description</title>
     <para>
-      Converts the sample rate of an audio file at sample rate Rin to
-    a sample rate of Rout.  Optionally the ratio (Rin / Rout) may be
-    linearly time-varying according to a set of (time, ratio) pairs in
-    an auxiliary file.
-    <note>This utility is suspect.  Better is to use libsamplerate.
-    srconv will be removed or replaced soon.</note>
+      Deprecated as of version 6.14. Use the <link linkend="src_conv"><citetitle>src_conv</citetitle></link> opcode instead. 
     </para>
-  </refsect1>
- 
-  <refsect1>
-    <title>Syntax</title>
-    <synopsis><command>srconv</command> [flags] infile</synopsis>
-  </refsect1>
-
-  <refsect1>
-    <title>Initialization</title>
-    <para>
-      Flags:
-      <itemizedlist>
-        <listitem><para>-<emphasis>P num</emphasis> = pitch
-    transposition ratio (srate / r) [don't specify both P and
-    r]</para></listitem> 
-        <listitem><para>-<emphasis>Q num</emphasis>  =quality factor
-    (1, 2, 3, or 4: default = 2)</para></listitem> 
-        <listitem><para>-<emphasis>i filnam</emphasis> = auxiliary 
-    breakpoints file (no breakpoint by default. i.e. No ratio change)
-    </para></listitem> 
-        <listitem><para>-<emphasis>r num</emphasis> = output sample
-    rate (must be specified)</para></listitem> 
-        <listitem><para>-<emphasis>o fnam</emphasis> = sound output
-    filename</para></listitem> 
-        <listitem><para>-<emphasis>A</emphasis> = create an AIFF
-    format output soundfile</para></listitem> 
-        <listitem><para>-<emphasis>J</emphasis> = create an IRCAM
-    format output soundfile</para></listitem> 
-        <listitem><para>-<emphasis>W</emphasis> = create a WAV format
-    output soundfile</para></listitem> 
-        <listitem><para>-<emphasis>h</emphasis> = no header on output
-    soundfile</para></listitem> 
-        <listitem><para>-<emphasis>c</emphasis> = 8-bit signed_char
-    sound samples</para></listitem> 
-        <listitem><para>-<emphasis>a</emphasis> = alaw sound
-    samples</para></listitem> 
-        <listitem><para>-<emphasis>8</emphasis> = 8-bit unsigned_char
-    sound samples</para></listitem> 
-        <listitem><para>-<emphasis>u</emphasis> = ulaw sound
-    samples</para></listitem> 
-        <listitem><para>-<emphasis>s</emphasis> = short_int sound
-    samples</para></listitem> 
-        <listitem><para>-<emphasis>l</emphasis> = long_int sound
-    samples</para></listitem> 
-        <listitem><para>-<emphasis>f</emphasis> = float sound
-    samples</para></listitem> 
-        <listitem><para>-<emphasis>r N</emphasis> = orchestra srate
-    override</para></listitem> 
-        <listitem><para>-<emphasis>K</emphasis> = Do not generate PEAK
-    chunks</para></listitem> 
-        <listitem><para>-<emphasis>R</emphasis> = continually rewrite
-    header while writing soundfile (WAV/AIFF)</para></listitem> 
-        <listitem><para>-<emphasis>H#</emphasis> = print a heartbeat
-    style 1, 2 or 3 at each soundfile write</para></listitem> 
-        <listitem><para>-<emphasis>N</emphasis> = notify (ring the
-    bell) when score or miditrack is done</para></listitem> 
-        <listitem><para>-<emphasis>- fnam</emphasis> = log output to
-    file</para></listitem> 
-      </itemizedlist>
-    </para>
-
-    <para>
-      This program performs arbitrary sample-rate conversion with high
-      fidelity.  The method is to step through the input at the
-      desired sampling increment, and to compute the output points as
-      appropriately weighted averages of the surrounding input points.
-      There are two cases to consider:
-
-      <orderedlist>
-        <listitem><para>sample rates are in a small-integer ratio -
-        weights are obtained from table.</para></listitem> 
-        <listitem><para>sample rates are in a large-integer ratio -
-        weights are linearly interpolated from
-        table.</para></listitem> 
-      </orderedlist>
-    </para>
-
-    <para>
-      Calculate increment: if decimating, then window is impulse
-    response of low-pass filter with cutoff frequency at half of
-    output sample rate; if interpolating, then window is impulse
-    response of lowpass filter with cutoff frequency at half of input
-    sample rate. 
-    </para>
-  </refsect1>
- 
-  <refsect1>
-    <title>See Also</title>
-    <para>
-      <link linkend="src_conv"><citetitle>src_conv</citetitle></link>
-    </para>
-  </refsect1>
-
-  <refsect1>
-    <title>Credits</title>
-    <para>Author: Mark Dolson</para>
-    <para>August 26, 1989</para>
-    <para>Author: &namejohn;</para>
-    <para>December 30, 2000</para>
   </refsect1>
 </refentry>


### PR DESCRIPTION
i think srconv should not any more be used.  i changed some pages.  perhaps the srconv page should be moved to the deprecated, too.