### PR TITLE
Remove 'mkdb' entry

### DIFF
--- a/utility/other.xml
+++ b/utility/other.xml
@@ -48,4 +48,4 @@
     &utilitymakecsd;
     &utilitymixer;
     &utilityscale;
- /section>
+ </section>

--- a/utility/other.xml
+++ b/utility/other.xml
@@ -1,7 +1,7 @@
 
 <section id="UtilityOther">
   <title>Other Csound Utilities (CS, CSB64ENC, ENVEXT, EXTRACTOR,
-  MAKECSD, MIXER, SCALE, MKDB)</title>
+  MAKECSD, MIXER, SCALE)</title>
   <para>The following miscellaneous utilities are available:
     <itemizedlist>
       <listitem>
@@ -39,12 +39,6 @@
           <link linkend="scaleutility"><citetitle>SCALE</citetitle></link>: Scale the amplitude of a sound file.
         </para>
       </listitem>
-      <listitem>
-        <para>
-          <link linkend="mkdb"><citetitle>MKDB</citetitle></link>:
-          Creates a plugin opcode catalog.
-        </para>
-      </listitem>
     </itemizedlist>
   </para>
     &utilitycs;
@@ -54,5 +48,4 @@
     &utilitymakecsd;
     &utilitymixer;
     &utilityscale;
-    &utilitymkdb;
-</section>
+ /section>


### PR DESCRIPTION
Utility is obsolete and no longer built
