### PR TITLE
Suppress confusing and unnecessary output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -692,7 +692,7 @@ SRCS =  $(COMMAND) $(CONTROL) $(XMLS) $(MIDI) $(OPCODES) $(ORCH) $(SCORE) \
 all: html
 
 $(XSL_HTML) $(XSL_HTMLHELP) $(XSL_PRINT) $(XSL_HTML_ONECHUNK): %: %.in
-	[ -d "$(XSL_BASE_PATH)" ] || (  \
+	@ [ -d "$(XSL_BASE_PATH)" ] || (  \
 	 echo "The XSL_BASE_PATH variable must be set to the XSL stylesheets installation directory" ; \
 	 false )
 	sed -e 's|@xsl_base_path@|$(XSL_BASE_PATH)|' $@.in > $@
@@ -704,7 +704,7 @@ examples-xml/stamp: examples $(wildcard examples/*)
 
 html: $(XSL_HTML) manual.xml $(SRCS) Makefile
 	rm -rf html
-	echo "Remember to use the html-dist target for distribution!"
+	@ echo "Remember to use the html-dist target for distribution!"
 	-mkdir -p ${HTML_DIR}
 	xsltproc  --xinclude -o ${HTML_DIR}/ ${XSL_HTML} manual.xml
 	cp -R images ${HTML_DIR}/
@@ -715,7 +715,7 @@ html: $(XSL_HTML) manual.xml $(SRCS) Makefile
 	rm -rf ${HTML_DIR}/images/CVS
 	rm -rf ${HTML_DIR}/images/callouts/CVS
 	rm -rf ${HTML_DIR}/examples/CVS
-	echo "Remember to use the html-dist target for distribution!"
+	@ echo "Remember to use the html-dist target for distribution!"
 
 html-dist:
 	python quickref.py


### PR DESCRIPTION
Lines 695 to 698 test for whether XSL_BASE_PATH is set correctly and include an error message if the test fails. The [README for the manual](https://github.com/csound/manual) warns users that "You may see this error: “The XSL_BASE_PATH variable must be set to the XSL stylesheets installation directory.” 

Given the existence of this warning in the README, it is confusing that even if `make` is successful, at the terminal you will see the error message from lines 695 to 698 about the XSL_BASE_PATH, Basically, even if the test passes (i.e., even if XLS_BASE_PATH is properly set), you see the echoed error message about the test *failing*. To avoid this confusion, I think that the lines with the test and error message should be suppressed at the terminal. If the test fails, you will still see the error message. But you won't see the error message if the test passes.

I have also used the `@` sign to suppress two echoed statements. This is a standard use of it. See https://stackoverflow.com/questions/9967105/suppress-echo-of-command-invocation-in-makefile.