### PR TITLE
realtimejack: remove scheduling example

### DIFF
--- a/overview/realtimejack.xml
+++ b/overview/realtimejack.xml
@@ -95,10 +95,6 @@ csound6:output2             (playback right)</screen>
     <screen>
       jackd -d alsa -P -r 48000 -p 64 -n 4 -zt &amp;
     csound -+rtaudio=jack -b 64 -B 256 [...]</screen>
-    with real time scheduling (as root):
-    <screen>
-      jackd -R -P 90 -d alsa -P -r 48000 -p 64 -n 2 -zt &amp;
-    csound --sched=80,90,10 -d -+rtaudio=jack -b 64 -B 192 [...]</screen>
     To improve performance, use ksmps values like 32 and 64.
   </para>
   <para>


### PR DESCRIPTION
According to a previous section about [scheduling](https://csound.com/docs/manual/RealTimeLinux.html) (at the bottom of the page),

> DO NOT use "--sched" if you are using JACK for audio output. JACK controls scheduling for the audio applications connected to it, and also tries to run at the highest possible priority. If the "--sched" flag is used, Csound and JACK will be competing rather than cooperating, resulting in extremely poor performance.

Thus, I believe the 2nd example in [realtimejack](https://csound.com/docs/manual/RealTimeJack.html) should be removed altogether.