### PR TITLE
Fix typo -idac -> -iadc

### DIFF
--- a/examples/in.csd
+++ b/examples/in.csd
@@ -1,7 +1,7 @@
 <CsoundSynthesizer>
 <CsOptions>
 ; Select audio/midi flags here according to platform
--odac   -idac   ;;;realtime audio I/O
+-odac   -iadc   ;;;realtime audio I/O
 ; For Non-realtime ouput leave only the line below:
 ; in.wav -W ;;; for file output any platform
 </CsOptions>

--- a/examples/inq.csd
+++ b/examples/inq.csd
@@ -1,7 +1,7 @@
 <CsoundSynthesizer>
 <CsOptions>
 ; Select audio/midi flags here according to platform
--odac  -idac ;;;realtime audio I/O
+-odac  -iadc ;;;realtime audio I/O
 ; For Non-realtime ouput leave only the line below:
 ; inq.wav -W ;;; for file output any platform
 </CsOptions>

--- a/examples/ins.csd
+++ b/examples/ins.csd
@@ -1,7 +1,7 @@
 <CsoundSynthesizer>
 <CsOptions>
 ; Select audio/midi flags here according to platform
--odac   -idac   ;;;realtime audio I/O
+-odac   -iadc   ;;;realtime audio I/O
 ; For Non-realtime ouput leave only the line below:
 ; ins.wav -W ;;; for file output any platform
 </CsOptions>

--- a/examples/makecsd.py
+++ b/examples/makecsd.py
@@ -15,7 +15,7 @@ for file in files:
 <CsOptions>
 ; Select audio/midi flags here according to platform
 ; Audio out   Audio in    Silent  MIDI in
--odac           -idac     -d       -M0  ;;;realtime output
+-odac           -iadc     -d       -M0  ;;;realtime output
 ; For Non-realtime ouput leave only the line below:
 ; -o ''' + file[:file.index('.orc')] + '''.wav -W ;;; for file output any platform
 </CsOptions>

--- a/examples/nchnls.csd
+++ b/examples/nchnls.csd
@@ -1,7 +1,7 @@
 <CsoundSynthesizer>
 <CsOptions>
 ; Select audio/midi flags here according to platform
--odac   -idac   ;;;realtime audio I/O
+-odac   -iadc   ;;;realtime audio I/O
 ; For Non-realtime ouput leave only the line below:
 ; nchnls.wav -W ;;; for file output any platform
 </CsOptions>

--- a/examples/nchnls_i.csd
+++ b/examples/nchnls_i.csd
@@ -1,7 +1,7 @@
 <CsoundSynthesizer>
 <CsOptions>
 ; Select audio/midi flags here according to platform
--odac  -idac ;;;realtime audio I/O
+-odac  -iadc ;;;realtime audio I/O
 ; For Non-realtime ouput leave only the line below:
 ; nchnls_i.wav -W ;;; for file output any platform
 </CsOptions>


### PR DESCRIPTION
I was reading the excellent Csound docs and I came across what I believe are some small typos; if I understand correctly the flag for realtime audio input is `-iadc` but there's a couple of `-idac`s in the docs. I figured it was worth making a PR to change this - apologies if the `-idac` is intended, I'm still quite new to Csound! Thanks so much for the great docs and for Csound itself, it's been really fun learning about it.