### PR TITLE
subsinstr p(X), passign & pcount gotchas

### DIFF
--- a/docs/opcodes/subinstr.md
+++ b/docs/opcodes/subinstr.md
@@ -34,7 +34,7 @@ The called instrument's p2 and p3 values will be identical to the host instrumen
 
 > :memo: **Note**
 >
-> Only the `p4` style accessors can read the actual parameter values passed to subinstruments. In a subinstrument, `p(4)` returns the host's `p4`, and so does `passign`. Furthermre, `pcount` returns the host's parameter count, not the subinsturment's. 
+> Only unparanthesized accessors like `p4` can read the actual parameter values passed to subinstruments. In contrast, in a subinstrument, opcodes calls relating to parameters like `p(4)` return the host's `p4`, and so does `passign`. Furthermre, `pcount` returns the host's parameter count, not the subinsturment's.
 
 ## Examples
 

--- a/docs/opcodes/subinstr.md
+++ b/docs/opcodes/subinstr.md
@@ -32,6 +32,10 @@ _p4, p5, ..._ -- Additional input values the are mapped to the called instrument
 
 The called instrument's p2 and p3 values will be identical to the host instrument's values. While the host instrument can [control its own duration](../control/durctl.md), any such attempts inside the called instrument will most likely have no effect.
 
+> :memo: **Note**
+>
+> Only the `p4` style accessors can read the actual parameter values passed to subinstruments. In a subinstrument, `p(4)` returns the host's `p4`, and so does `passign`. Furthermre, `pcount` returns the host's parameter count, not the subinsturment's. 
+
 ## Examples
 
 === "Modern"

--- a/docs/opcodes/subinstr.md
+++ b/docs/opcodes/subinstr.md
@@ -34,7 +34,7 @@ The called instrument's p2 and p3 values will be identical to the host instrumen
 
 > :memo: **Note**
 >
-> Only unparanthesized accessors like `p4` can read the actual parameter values passed to subinstruments. In contrast, in a subinstrument, opcodes calls relating to parameters like `p(4)` return the host's `p4`, and so does `passign`. Furthermre, `pcount` returns the host's parameter count, not the subinsturment's.
+> Only unparenthesized accessors like `p4` can read the actual parameter values passed to subinstruments. In contrast, in a subinstrument, opcodes calls relating to parameters like `p(4)` return the host's `p4`, and so does `passign`. Furthermre, `pcount` returns the host's parameter count, not the subinsturment's.
 
 ## Examples
 


### PR DESCRIPTION
Document csound/csound#2197.

By the way, is there an official terminology for parameter accessors like `p4`? As opposed to `p(4)` or `p 4` which are opcode calls that behave differently in this context.
